### PR TITLE
Hotfix for object in custom details incident columns - JSON stringify objects to avoid render error

### DIFF
--- a/src/components/IncidentTable/IncidentTableComponent.test.js
+++ b/src/components/IncidentTable/IncidentTableComponent.test.js
@@ -57,6 +57,13 @@ describe('IncidentTableComponent', () => {
             width: 100,
             columnType: 'alert',
           },
+          {
+            Header: 'object_details',
+            accessorPath: 'details.object_details',
+            aggregator: null,
+            width: 100,
+            columnType: 'alert',
+          },
         ],
       },
       incidentActions: {
@@ -107,5 +114,22 @@ describe('IncidentTableComponent', () => {
     const sanitizedUrl = sanitizeUrl(url);
 
     expect(validator.isURL(sanitizedUrl)).toBeTruthy();
+  });
+
+  it('should render cell with JSON stringified value for custom detail field', () => {
+    store = mockStore(baseStore);
+    const wrapper = componentWrapper(store, IncidentTableComponent);
+
+    const incidentNumber = 1;
+    const customDetailField = 'object_details';
+    const jsonValue = wrapper
+      .find('[role="row"]')
+      .get(incidentNumber)
+      .props.children.find((td) => td.key.includes(customDetailField)).props.children.props
+      .cell.value;
+
+    // jsonValue should include a key with value 'value1'
+    expect(typeof jsonValue).toBe('object');
+    expect(JSON.stringify(jsonValue)).toContain('value1');
   });
 });

--- a/src/config/incident-table-columns.js
+++ b/src/config/incident-table-columns.js
@@ -675,24 +675,41 @@ export const customReactTableColumnSchema = (
       value,
     }) => {
       // Determine if content should be rendered as link or plaintext
+      let valueStr;
+      switch (typeof value) {
+        case 'string':
+          valueStr = value;
+          break;
+        case 'undefined':
+          valueStr = '';
+          break;
+        case 'object':
+          valueStr = value ? JSON.stringify(value) : '';
+          break;
+        default:
+          valueStr = `${value}`;
+      }
+
       try {
-        const sanitizedValue = sanitizeUrl(value);
-        if (validator.isURL(sanitizedValue)) {
-          return (
-            <a
-              href={sanitizedValue}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="td-wrapper"
-            >
-              {sanitizedValue}
-            </a>
-          );
+        if (typeof value === 'string') {
+          const sanitizedValue = sanitizeUrl(valueStr);
+          if (validator.isURL(sanitizedValue)) {
+            return (
+              <a
+                href={sanitizedValue}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="td-wrapper"
+              >
+                {sanitizedValue}
+              </a>
+            );
+          }
         }
       } catch (e) {
         console.log(e);
       }
-      return <div className="td-wrapper">{value}</div>;
+      return <div className="td-wrapper">{valueStr}</div>;
     },
   };
 };

--- a/src/mocks/incidents.test.js
+++ b/src/mocks/incidents.test.js
@@ -38,6 +38,9 @@ const generateMockAlert = () => {
           quote,
           'some obsecure field': uuid,
           link,
+          object_details: {
+            key1: 'value1',
+          },
         },
         event_class: jobType,
         message,


### PR DESCRIPTION
Value for column renderer should always be string - if cell is object, JSON.stringify it.

When adding a custom column, if you specify a field that has/may have an object and not a string, then ensure it's rendered as a string.

Resolves blank screen issue with `Uncaught Error: Objects are not valid as a React child (found: object with keys {quote}). If you meant to render a collection of children, use an array instead.` console error.

![Screenshot 2023-06-08 at 12 15 50](https://github.com/PagerDuty/pd-live-react/assets/1533562/a8c1dc92-c93c-4c3f-9b58-4ee9d2c1cda0)
