### PR TITLE
fix log entries since date calculation

### DIFF
--- a/src/mocks/incidents.test.js
+++ b/src/mocks/incidents.test.js
@@ -97,7 +97,7 @@ const generateMockNote = () => {
 
 export const generateMockNotes = (num) => Array.from({ length: num }, () => generateMockNote());
 
-const generateMockIncident = () => {
+export const generateMockIncident = () => {
   // Generate Faker stubs for incident (slimmed down)
   const incidentNumber = Number(faker.string.numeric(5));
   const title = faker.lorem.words(20);

--- a/src/mocks/log_entries.test.js
+++ b/src/mocks/log_entries.test.js
@@ -1,0 +1,34 @@
+import {
+  faker,
+} from '@faker-js/faker';
+import generateMockIncident from './incidents.test';
+
+const generateMockLogEntry = () => {
+  const type = faker.helpers.arrayElement(['notify_log_entry', 'acknowledge_log_entry']);
+  const summary = faker.lorem.words(20);
+  const createdAt = faker.date
+    .between({ from: '2020-01-01T00:00:00.000Z', to: '2022-01-01T00:00:00.000Z' })
+    .toISOString();
+  const agent = { id: faker.string.alphanumeric(7) };
+  const channel = { type: 'auto' };
+  const service = { id: faker.string.alphanumeric(7) };
+  const incident = generateMockIncident();
+  const teams = [{ id: faker.string.alphanumeric(7) }];
+
+  return {
+    type,
+    summary,
+    created_at: createdAt,
+    channel,
+    agent,
+    service,
+    incident,
+    teams,
+  };
+};
+
+export const generateMockLogEntries = (num) => Array.from({ length: num }, () => generateMockLogEntry());
+
+export default generateMockLogEntries;
+
+test.skip('Mock log entries', () => 1);

--- a/src/mocks/log_entries.test.js
+++ b/src/mocks/log_entries.test.js
@@ -1,9 +1,12 @@
 import {
   faker,
 } from '@faker-js/faker';
-import generateMockIncident from './incidents.test';
+import {
+  generateMockIncident,
+} from './incidents.test';
 
 const generateMockLogEntry = () => {
+  const id = faker.string.alphanumeric(7);
   const type = faker.helpers.arrayElement(['notify_log_entry', 'acknowledge_log_entry']);
   const summary = faker.lorem.words(20);
   const createdAt = faker.date
@@ -16,6 +19,7 @@ const generateMockLogEntry = () => {
   const teams = [{ id: faker.string.alphanumeric(7) }];
 
   return {
+    id,
     type,
     summary,
     created_at: createdAt,

--- a/src/redux/incidents/reducers.js
+++ b/src/redux/incidents/reducers.js
@@ -499,7 +499,7 @@ const incidents = produce(
     fetchingIncidentNotes: false,
     fetchingIncidentAlerts: false,
     // refreshingIncidents: false,
-    lastFetchDate: new Date(),
+    lastFetchDate: undefined,
     error: null,
   },
 );

--- a/src/redux/log_entries/reducers.js
+++ b/src/redux/log_entries/reducers.js
@@ -21,10 +21,13 @@ const logEntries = produce(
         break;
 
       case FETCH_LOG_ENTRIES_COMPLETED:
-        draft.fetchingData = false;
-        draft.status = FETCH_LOG_ENTRIES_COMPLETED;
+        if (action.latestLogEntryDate) {
+          draft.latestLogEntryDate = action.latestLogEntryDate;
+        }
         draft.logEntries = action.logEntries;
         draft.recentLogEntries = action.recentLogEntries;
+        draft.fetchingData = false;
+        draft.status = FETCH_LOG_ENTRIES_COMPLETED;
         break;
 
       case FETCH_LOG_ENTRIES_ERROR:
@@ -71,6 +74,7 @@ const logEntries = produce(
     }
   },
   {
+    latestLogEntryDate: null,
     logEntries: [],
     recentLogEntries: {},
     addList: [],

--- a/src/redux/log_entries/sagas.js
+++ b/src/redux/log_entries/sagas.js
@@ -8,13 +8,6 @@ import {
 import i18next from 'i18n';
 
 import {
-  RESOLVE_LOG_ENTRY,
-  TRIGGER_LOG_ENTRY,
-  ANNOTATE_LOG_ENTRY,
-  LINK_LOG_ENTRY,
-  UNLINK_LOG_ENTRY,
-} from 'util/log-entries';
-import {
   pd, pdParallelFetch,
 } from 'util/pd-api-wrapper';
 
@@ -22,20 +15,13 @@ import {
   UPDATE_CONNECTION_STATUS_REQUESTED,
 } from 'redux/connection/actions';
 import {
-  FETCH_INCIDENTS_REQUESTED,
-  PROCESS_LOG_ENTRIES,
-  // UPDATE_INCIDENTS_LIST,
+  FETCH_INCIDENTS_REQUESTED, PROCESS_LOG_ENTRIES,
 } from 'redux/incidents/actions';
-
-import selectIncidents from 'redux/incidents/selectors';
 
 import {
   FETCH_LOG_ENTRIES_REQUESTED,
   FETCH_LOG_ENTRIES_COMPLETED,
   FETCH_LOG_ENTRIES_ERROR,
-  UPDATE_RECENT_LOG_ENTRIES,
-  UPDATE_RECENT_LOG_ENTRIES_COMPLETED,
-  UPDATE_RECENT_LOG_ENTRIES_ERROR,
   CLEAN_RECENT_LOG_ENTRIES,
   CLEAN_RECENT_LOG_ENTRIES_COMPLETED,
   CLEAN_RECENT_LOG_ENTRIES_ERROR,
@@ -64,7 +50,10 @@ export function* getLogEntries(action) {
 
     let logEntries;
     try {
-      logEntries = yield call(pdParallelFetch, 'log_entries', params, null, { priority: 5, maxRecords: 1000 });
+      logEntries = yield call(pdParallelFetch, 'log_entries', params, null, {
+        priority: 5,
+        maxRecords: 1000,
+      });
     } catch (e) {
       if (e.message && e.message.startsWith('Too many records')) {
         // eslint-disable-next-line no-console
@@ -98,7 +87,9 @@ export function* getLogEntries(action) {
       ),
     };
 
-    const latestLogEntryDate = logEntries.length > 0 ? new Date(Math.max(...logEntries.map((x) => new Date(x.created_at)))) : undefined;
+    const latestLogEntryDate = logEntries.length > 0
+      ? new Date(Math.max(...logEntries.map((x) => new Date(x.created_at))))
+      : undefined;
 
     yield put({
       type: FETCH_LOG_ENTRIES_COMPLETED,

--- a/src/redux/log_entries/sagas.js
+++ b/src/redux/log_entries/sagas.js
@@ -47,7 +47,6 @@ export function* getLogEntries(action) {
       since: since.toISOString().replace(/\.[\d]{3}/, ''),
       'include[]': ['incidents', 'linked_incidents', 'external_references', 'channels'],
     };
-
     let logEntries;
     try {
       logEntries = yield call(pdParallelFetch, 'log_entries', params, null, {

--- a/src/redux/log_entries/sagas.test.js
+++ b/src/redux/log_entries/sagas.test.js
@@ -1,17 +1,29 @@
 import {
   select,
 } from 'redux-saga/effects';
+
 import {
   expectSaga,
 } from 'redux-saga-test-plan';
+import * as matchers from 'redux-saga-test-plan/matchers';
+import { throwError } from 'redux-saga-test-plan/providers';
 
 import {
   generateMockLogEntries,
 } from 'mocks/log_entries.test';
 
 import {
-  FETCH_LOG_ENTRIES_REQUESTED, FETCH_LOG_ENTRIES_COMPLETED,
+  pdParallelFetch,
+} from 'util/pd-api-wrapper';
+
+import {
+  FETCH_LOG_ENTRIES_REQUESTED, FETCH_LOG_ENTRIES_COMPLETED, FETCH_LOG_ENTRIES_ERROR,
 } from './actions';
+
+import {
+  FETCH_INCIDENTS_REQUESTED,
+  PROCESS_LOG_ENTRIES,
+} from '../incidents/actions';
 
 import logEntries from './reducers';
 
@@ -22,26 +34,61 @@ import {
 } from './sagas';
 
 // FIXME: Need to complete this test
-xdescribe('Sagas: Log Entries', () => {
+describe('Sagas: Log Entries', () => {
   const mockLogEntries = generateMockLogEntries(10);
+  const mockRecentLogEntries = Object.assign(
+    {}, ...mockLogEntries.map((logEntry) => ({ [logEntry.id]: new Date(logEntry.created_at) })),
+  );
+  const mockLatestLogEntryDate = new Date(Math.max(...Object.values(mockRecentLogEntries)));
 
-  it('should be tested', () => expectSaga(getLogEntriesAsync)
+  it('fetches log entries', () => expectSaga(getLogEntriesAsync)
     .withReducer(logEntries)
-    .provide([[select(selectLogEntries), { logEntries: mockLogEntries }]])
+    .provide(
+      [
+        [select(selectLogEntries), { logEntries: [], recentLogEntries: {} }],
+        [matchers.call.fn(pdParallelFetch), mockLogEntries],
+      ],
+    )
     .dispatch({
       type: FETCH_LOG_ENTRIES_REQUESTED,
       since: new Date(),
     })
-    .put({
-      type: FETCH_LOG_ENTRIES_COMPLETED,
-      logEntries: mockLogEntries,
-      // FIXME: recentLogEntries has the format { logEntryId: date }
-      recentLogEntries: mockLogEntries,
-      latestLogEntryDate: new Date(),
-    })
-    .silentRun()
+    .run()
     .then((result) => {
-      expect(result.storeState.status).toEqual(FETCH_LOG_ENTRIES_COMPLETED);
-      expect(result.storeState.log_entries).toEqual(mockLogEntries);
+      const {
+        storeState,
+        effects,
+      } = result;
+      expect(effects.call).toHaveLength(1);
+      expect(effects.put).toHaveLength(2);
+      expect(effects.put[0].payload.action.type).toEqual(FETCH_LOG_ENTRIES_COMPLETED);
+      expect(effects.put[1].payload.action.type).toEqual(PROCESS_LOG_ENTRIES);
+      expect(storeState.status).toEqual(FETCH_LOG_ENTRIES_COMPLETED);
+      expect(storeState.logEntries).toHaveLength(mockLogEntries.length);
+      expect(storeState.recentLogEntries).toEqual(mockRecentLogEntries);
+      expect(storeState.latestLogEntryDate).toEqual(mockLatestLogEntryDate);
+    }));
+
+  it('fetches incidents instead when log entries is too long', () => expectSaga(getLogEntriesAsync)
+    .withReducer(logEntries)
+    .provide(
+      [
+        [select(selectLogEntries), { logEntries: [], recentLogEntries: {} }],
+        [matchers.call.fn(pdParallelFetch), throwError(new Error('Too many records: 1001 > 1000'))],
+      ],
+    )
+    .dispatch({
+      type: FETCH_LOG_ENTRIES_REQUESTED,
+      since: new Date(),
+    })
+    .run()
+    .then((result) => {
+      const {
+        effects,
+      } = result;
+      expect(effects.call).toHaveLength(1);
+      expect(effects.put).toHaveLength(2);
+      expect(effects.put[0].payload.action.type).toEqual(FETCH_LOG_ENTRIES_ERROR);
+      expect(effects.put[1].payload.action.type).toEqual(FETCH_INCIDENTS_REQUESTED);
     }));
 });

--- a/src/redux/log_entries/sagas.test.js
+++ b/src/redux/log_entries/sagas.test.js
@@ -1,0 +1,47 @@
+import {
+  select,
+} from 'redux-saga/effects';
+import {
+  expectSaga,
+} from 'redux-saga-test-plan';
+
+import {
+  generateMockLogEntries,
+} from 'mocks/log_entries.test';
+
+import {
+  FETCH_LOG_ENTRIES_REQUESTED, FETCH_LOG_ENTRIES_COMPLETED,
+} from './actions';
+
+import logEntries from './reducers';
+
+import selectLogEntries from './selectors';
+
+import {
+  getLogEntriesAsync,
+} from './sagas';
+
+// FIXME: Need to complete this test
+xdescribe('Sagas: Log Entries', () => {
+  const mockLogEntries = generateMockLogEntries(10);
+
+  it('should be tested', () => expectSaga(getLogEntriesAsync)
+    .withReducer(logEntries)
+    .provide([[select(selectLogEntries), { logEntries: mockLogEntries }]])
+    .dispatch({
+      type: FETCH_LOG_ENTRIES_REQUESTED,
+      since: new Date(),
+    })
+    .put({
+      type: FETCH_LOG_ENTRIES_COMPLETED,
+      logEntries: mockLogEntries,
+      // FIXME: recentLogEntries has the format { logEntryId: date }
+      recentLogEntries: mockLogEntries,
+      latestLogEntryDate: new Date(),
+    })
+    .silentRun()
+    .then((result) => {
+      expect(result.storeState.status).toEqual(FETCH_LOG_ENTRIES_COMPLETED);
+      expect(result.storeState.log_entries).toEqual(mockLogEntries);
+    }));
+});

--- a/src/util/pd-api-wrapper.js
+++ b/src/util/pd-api-wrapper.js
@@ -145,6 +145,9 @@ export const pdParallelFetch = async (
   const firstPage = (
     await throttledPdAxiosRequest('GET', endpoint, requestParams, undefined, axiosRequestOptions)
   ).data;
+  if (options.maxRecords && firstPage.total > options.maxRecords) {
+    throw new Error(`Too many records: ${firstPage.total} > ${options.maxRecords}`);
+  }
   const fetchedData = firstPage[endpointIdentifier(endpoint)];
 
   const promises = [];


### PR DESCRIPTION
Fix for #92

* When calculating the since date for polling log entries, use the incident last fetch date, unless the latest log entry fetched has a later date
* Subtract 1 second from each to avoid missing log entries that may have come later in the second we last fetched
* When polling log entries and the total number of records is >1000, stop and fetch incidents instead
