### PR TITLE
fix errors in log entries polling logic

### DIFF
--- a/src/redux/incidents/reducers.js
+++ b/src/redux/incidents/reducers.js
@@ -63,6 +63,14 @@ import {
   FILTER_INCIDENTS_LIST_BY_QUERY_ERROR,
 } from './actions';
 
+const uniqOnId = (arr) => {
+  const map = new Map();
+  arr.forEach((item) => {
+    map.set(item.id, item);
+  });
+  return [...map.values()];
+};
+
 const incidents = produce(
   (draft, action) => {
     switch (action.type) {
@@ -219,9 +227,9 @@ const incidents = produce(
           if (!draft.incidentAlerts[incidentId]) {
             draft.incidentAlerts[incidentId] = [];
           }
-          draft.incidentAlerts[incidentId] = draft.incidentAlerts[incidentId].concat(
+          draft.incidentAlerts[incidentId] = uniqOnId(draft.incidentAlerts[incidentId].concat(
             action.incidentAlertsMap[incidentId],
-          );
+          ));
         }
         for (let i = 0; i < Object.keys(action.incidentAlertsUnlinkMap).length; i++) {
           const incidentId = Object.keys(action.incidentAlertsUnlinkMap)[i];

--- a/src/util/pd-api-wrapper.js
+++ b/src/util/pd-api-wrapper.js
@@ -58,9 +58,9 @@ export const pdAxiosRequest = async (method, endpoint, params = {}, data = {}) =
       return `Token token=${tokenObj.token}`;
     })(),
     Accept: 'application/vnd.pagerduty+json;version=2',
-    'content-type': 'application/json; charset=utf-8',
+    'Content-Type': 'application/json; charset=utf-8',
   },
-  params,
+  params: { ...params, rand: Math.random().toString(36).substring(2, 7) },
   data,
 });
 


### PR DESCRIPTION
Log entries polling had some problems:

* interval was getting reset too often (dependency array had too many things in it)
* also it looks like the browser was caching what it thought were identical requests when we were polling and the since date had not changed -- added a random query param to bypass the cache
* multiple log entries fetches could be started at once, that should not be possible now
* logging as error when skipping polls just so that we can see it in RUM

I'd like to deploy this as a hotfix because the current behavior is pretty bad