### PR TITLE
reduce request expiration from 60s to 10s

### DIFF
--- a/src/util/pd-api-wrapper.js
+++ b/src/util/pd-api-wrapper.js
@@ -81,12 +81,12 @@ export const throttledPdAxiosRequest = (
   params = {},
   data = {},
   options = {
-    expiration: 60 * 1000,
+    expiration: 10 * 1000,
     priority: 5,
   },
 ) => limiter.schedule(
   {
-    expiration: options.expiration || 60 * 1000,
+    expiration: options?.expiration || 10 * 1000,
     priority: options.priority || 5,
     id: `${method}-${endpoint}-${JSON.stringify(params)}-${Date.now()}`,
   },
@@ -133,7 +133,7 @@ export const pdParallelFetch = async (
   };
 
   const axiosRequestOptions = {
-    expiration: 60 * 1000,
+    expiration: options?.expiration || 10 * 1000,
     priority: options.priority,
   };
 


### PR DESCRIPTION
Reducing request expiration (if network is down, etc.) from 60s to 10s to reduce stuck requests executing in bottleneck