### PR TITLE
increase request expiration to 30s

### DIFF
--- a/src/util/pd-api-wrapper.js
+++ b/src/util/pd-api-wrapper.js
@@ -81,12 +81,12 @@ export const throttledPdAxiosRequest = (
   params = {},
   data = {},
   options = {
-    expiration: 10 * 1000,
+    expiration: 30 * 1000,
     priority: 5,
   },
 ) => limiter.schedule(
   {
-    expiration: options?.expiration || 10 * 1000,
+    expiration: options?.expiration || 30 * 1000,
     priority: options.priority || 5,
     id: `${method}-${endpoint}-${JSON.stringify(params)}-${Date.now()}`,
   },
@@ -133,7 +133,7 @@ export const pdParallelFetch = async (
   };
 
   const axiosRequestOptions = {
-    expiration: options?.expiration || 10 * 1000,
+    expiration: options?.expiration || 30 * 1000,
     priority: options.priority,
   };
 


### PR DESCRIPTION
Timeout was previously 60s but reduced to 10s. However, this may be too short as some very large customers report that loading users / escalation policies is taking more than 10s and so currently timing out.