### PR TITLE
Add relative dates setting

### DIFF
--- a/cypress/e2e/Query/query.spec.js
+++ b/cypress/e2e/Query/query.spec.js
@@ -9,9 +9,6 @@ import {
 import {
   acceptDisclaimer,
   waitForIncidentTable,
-  updateAutoAcceptIncidentQuery,
-  activateButton,
-  deactivateButton,
   checkIncidentCellContentAllRows,
   checkIncidentCellIconAllRows,
   manageIncidentTableColumns,

--- a/cypress/e2e/Settings/settings.spec.js
+++ b/cypress/e2e/Settings/settings.spec.js
@@ -13,8 +13,7 @@ import {
   updateRelativeDates,
   manageIncidentTableColumns,
   manageCustomAlertColumnDefinitions,
-  // activateButton,
-  // priorityNames,
+  checkIncidentCellContentAllRows,
 } from '../../support/util/common';
 
 describe('Manage Settings', { failFast: { enabled: false } }, () => {
@@ -216,6 +215,10 @@ describe('Manage Settings', { failFast: { enabled: false } }, () => {
         .then((state) => expect(
           state.settings.relativeDates,
         ).to.equal(relativeDates));
+
+      if (relativeDates) {
+        checkIncidentCellContentAllRows('Created At', 'ago', 'contain.text');
+      }
     });
   });
 });

--- a/cypress/e2e/Settings/settings.spec.js
+++ b/cypress/e2e/Settings/settings.spec.js
@@ -10,6 +10,7 @@ import {
   updateDefaultSinceDateLookback,
   updateMaxRateLimit,
   updateDarkMode,
+  updateRelativeDates,
   manageIncidentTableColumns,
   manageCustomAlertColumnDefinitions,
   // activateButton,
@@ -204,5 +205,17 @@ describe('Manage Settings', { failFast: { enabled: false } }, () => {
       .then((state) => expect(
         state.settings.darkMode,
       ).to.equal(!currentDarkMode));
+  });
+
+  it('Update relative dates', () => {
+    [false, true].forEach((relativeDates) => {
+      updateRelativeDates(relativeDates);
+      cy.window()
+        .its('store')
+        .invoke('getState')
+        .then((state) => expect(
+          state.settings.relativeDates,
+        ).to.equal(relativeDates));
+    });
   });
 });

--- a/cypress/support/util/common.js
+++ b/cypress/support/util/common.js
@@ -59,7 +59,7 @@ export const checkIncidentCellContent = (incidentId, incidentHeader, content) =>
     .should('have.text', content);
 };
 
-export const checkIncidentCellContentAllRows = (incidentHeader, content) => {
+export const checkIncidentCellContentAllRows = (incidentHeader, content, match = 'have.text') => {
   cy.wait(2000);
   cy.get('.incident-table-fixed-list > div').then(($tbody) => {
     const visibleIncidentCount = $tbody.find('[role="row"]').length;
@@ -69,7 +69,7 @@ export const checkIncidentCellContentAllRows = (incidentHeader, content) => {
       )
         .scrollIntoView()
         .should('be.visible')
-        .should('have.text', content);
+        .should(match, content);
     }
   });
 };

--- a/cypress/support/util/common.js
+++ b/cypress/support/util/common.js
@@ -290,20 +290,18 @@ export const updateMaxRateLimit = (limit = 200) => {
   checkActionAlertsModalContent('Updated user profile settings');
 };
 
-export const updateAutoAcceptIncidentQuery = (autoAcceptIncidentsQuery = false) => {
+export const updateRelativeDates = (relativeDates = false) => {
   cy.get('.settings-panel-dropdown').click();
   cy.get('.dropdown-item').contains('Settings').click();
-  cy.get('.nav-item').contains('User Profile').click();
 
-  if (autoAcceptIncidentsQuery) {
-    cy.get('#user-profile-auto-accept-incident-query-checkbox').check({ force: true });
+  if (relativeDates) {
+    cy.get('#relative-dates-switch').check({ force: true });
   } else {
-    cy.get('#user-profile-auto-accept-incident-query-checkbox').uncheck({ force: true });
+    cy.get('#relative-dates-switch').uncheck({ force: true });
   }
 
-  cy.get('.btn').contains('Update User Profile').click();
+  cy.get('#save-settings-button').click();
   checkActionAlertsModalContent('Updated user profile settings');
-  cy.get('.close').click();
 };
 
 export const updateDarkMode = () => {

--- a/src/components/SettingsModal/SettingsModalComponent.js
+++ b/src/components/SettingsModal/SettingsModalComponent.js
@@ -58,6 +58,7 @@ import {
   setServerSideFiltering as setServerSideFilteringConnected,
   setSearchAllCustomDetails as setSearchAllCustomDetailsConnected,
   setRespondersInEpFilter as setRespondersInEpFilterConnected,
+  setRelativeDates as setRelativeDatesConnected,
 } from 'redux/settings/actions';
 
 const SettingsModalComponent = () => {
@@ -74,6 +75,7 @@ const SettingsModalComponent = () => {
     serverSideFiltering,
     searchAllCustomDetails,
     respondersInEpFilter,
+    relativeDates,
   } = useSelector((state) => state.settings);
   const currentUserLocale = useSelector((state) => state.users.currentUserLocale);
 
@@ -95,6 +97,9 @@ const SettingsModalComponent = () => {
   const setRespondersInEpFilter = (newRespondersInEpFilter) => {
     dispatch(setRespondersInEpFilterConnected(newRespondersInEpFilter));
   };
+  const setRelativeDates = (newRelativeDates) => {
+    dispatch(setRelativeDatesConnected(newRelativeDates));
+  };
 
   const localeOptions = Object.keys(locales).map((locale) => ({
     label: locales[locale],
@@ -108,6 +113,7 @@ const SettingsModalComponent = () => {
   const [tempServerSideFiltering, setTempServerSideFiltering] = useState(serverSideFiltering);
   const [tempSearchAllCustomDetails, setTempSearchAllCustomDetails] = useState(searchAllCustomDetails);
   const [tempRespondersInEpFilter, setTempRespondersInEpFilter] = useState(respondersInEpFilter);
+  const [tempRelativeDates, setTempRelativeDates] = useState(relativeDates);
 
   const saveSettings = () => {
     if (selectedLocale !== currentUserLocale) {
@@ -127,6 +133,9 @@ const SettingsModalComponent = () => {
     }
     if (tempRespondersInEpFilter !== respondersInEpFilter) {
       setRespondersInEpFilter(tempRespondersInEpFilter);
+    }
+    if (tempRelativeDates !== relativeDates) {
+      setRelativeDates(tempRelativeDates);
     }
   };
 
@@ -240,6 +249,19 @@ const SettingsModalComponent = () => {
                 }}
               >
                 {t('Escalation Policy filter searches responders as well as assignees')}
+              </Switch>
+            </FormControl>
+            <FormControl>
+              <FormLabel htmlFor="relative-dates-switch">{t('Relative Dates')}</FormLabel>
+              <Switch
+                id="relative-dates-switch"
+                isChecked={tempRelativeDates}
+                aria-label={t('Date columns are shown relative to the current time')}
+                onChange={(e) => {
+                  setTempRelativeDates(e.target.checked);
+                }}
+              >
+                {t('Date columns are shown relative to the current time')}
               </Switch>
             </FormControl>
           </Stack>

--- a/src/components/SettingsModal/SettingsModalComponent.test.js
+++ b/src/components/SettingsModal/SettingsModalComponent.test.js
@@ -20,7 +20,10 @@ describe('SettingsModalComponent', () => {
         displaySettingsModal: true,
         defaultSinceDateTenor: '1 Day',
         maxRateLimit: MAX_RATE_LIMIT_LOWER,
-        darkMode: false,
+        serverSideFiltering: true,
+        searchAllCustomDetails: true,
+        respondersInEpFilter: true,
+        relativeDates: true,
       },
       users: {
         currentUserLocale: 'en-GB',
@@ -44,7 +47,9 @@ describe('SettingsModalComponent', () => {
       MAX_RATE_LIMIT_LOWER,
     );
 
-    expect(wrapper.find('input#server-side-filtering-switch').prop('checked'));
-    expect(wrapper.find('input#search-all-custom-details-switch').prop('checked'));
+    expect(wrapper.find('input#server-side-filtering-switch').prop('checked')).toBeTruthy();
+    expect(wrapper.find('input#search-all-custom-details-switch').prop('checked')).toBeTruthy();
+    expect(wrapper.find('input#responders-in-ep-filter-switch').prop('checked')).toBeTruthy();
+    expect(wrapper.find('input#relative-dates-switch').prop('checked')).toBeTruthy();
   });
 });

--- a/src/config/column-generator.js
+++ b/src/config/column-generator.js
@@ -43,6 +43,10 @@ import StatusComponent from 'components/IncidentTable/subcomponents/StatusCompon
 import NumAlertsComponent from 'components/IncidentTable/subcomponents/NumAlertsComponent';
 import PersonInitialsComponents from 'components/IncidentTable/subcomponents/PersonInitialsComponents';
 
+import {
+  useSelector,
+} from 'react-redux';
+
 const CellDiv = ({
   children,
 }) => <div className="td-wrapper">{children}</div>;
@@ -70,9 +74,24 @@ const renderLinkCells = (linkObjs) => {
 
 const renderDateCell = ({
   iso8601Date,
-}) => (
-  <CellDiv>{moment(iso8601Date).format(DATE_FORMAT)}</CellDiv>
-);
+}) => {
+  const {
+    relativeDates,
+  } = useSelector((state) => state.settings);
+  if (!iso8601Date) {
+    return <CellDiv>--</CellDiv>;
+  }
+  if (relativeDates) {
+    return (
+      <CellDiv>
+        <Tooltip label={moment(iso8601Date).format(DATE_FORMAT)}>
+          {moment(iso8601Date).fromNow()}
+        </Tooltip>
+      </CellDiv>
+    );
+  }
+  return <CellDiv>{moment(iso8601Date).format(DATE_FORMAT)}</CellDiv>;
+};
 
 const renderPlainTextCell = ({
   value,

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -3,6 +3,7 @@ import {
   initReactI18next,
 } from 'react-i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
+import moment from 'moment';
 
 import gb from 'date-fns/locale/en-GB';
 import us from 'date-fns/locale/en-US';
@@ -77,6 +78,114 @@ export const lngs = {
     nativeName: 'Português (Brasil)',
   },
 };
+
+moment.locale('fr', {
+  relativeTime: {
+    future: 'dans %s',
+    past: 'il y a %s',
+    s: 'quelques secondes',
+    m: 'une minute',
+    mm: '%d minutes',
+    h: 'une heure',
+    hh: '%d heures',
+    d: 'un jour',
+    dd: '%d jours',
+    M: 'un mois',
+    MM: '%d mois',
+    y: 'un an',
+    yy: '%d ans',
+  },
+});
+
+moment.locale('es', {
+  relativeTime: {
+    future: 'en %s',
+    past: 'hace %s',
+    s: 'unos segundos',
+    m: 'un minuto',
+    mm: '%d minutos',
+    h: 'una hora',
+    hh: '%d horas',
+    d: 'un día',
+    dd: '%d días',
+    M: 'un mes',
+    MM: '%d meses',
+    y: 'un año',
+    yy: '%d años',
+  },
+});
+
+moment.locale('de', {
+  relativeTime: {
+    future: 'in %s',
+    past: 'vor %s',
+    s: 'ein paar Sekunden',
+    m: 'einer Minute',
+    mm: '%d Minuten',
+    h: 'einer Stunde',
+    hh: '%d Stunden',
+    d: 'einem Tag',
+    dd: '%d Tagen',
+    M: 'einem Monat',
+    MM: '%d Monaten',
+    y: 'einem Jahr',
+    yy: '%d Jahren',
+  },
+});
+
+moment.locale('ja', {
+  relativeTime: {
+    future: '%s後',
+    past: '%s前',
+    s: '数秒',
+    m: '1分',
+    mm: '%d分',
+    h: '1時間',
+    hh: '%d時間',
+    d: '1日',
+    dd: '%d日',
+    M: '1ヶ月',
+    MM: '%dヶ月',
+    y: '1年',
+    yy: '%d年',
+  },
+});
+
+moment.locale('id', {
+  relativeTime: {
+    future: 'dalam %s',
+    past: '%s yang lalu',
+    s: 'beberapa detik',
+    m: 'semenit',
+    mm: '%d menit',
+    h: 'sejam',
+    hh: '%d jam',
+    d: 'sehari',
+    dd: '%d hari',
+    M: 'sebulan',
+    MM: '%d bulan',
+    y: 'setahun',
+    yy: '%d tahun',
+  },
+});
+
+moment.locale('pt', {
+  relativeTime: {
+    future: 'em %s',
+    past: 'há %s',
+    s: 'alguns segundos',
+    m: 'um minuto',
+    mm: '%d minutos',
+    h: 'uma hora',
+    hh: '%d horas',
+    d: 'um dia',
+    dd: '%d dias',
+    M: 'um mês',
+    MM: '%d meses',
+    y: 'um ano',
+    yy: '%d anos',
+  },
+});
 
 // locales is generated from the lngs object for compatibility with original locales implementation
 /* eslint-disable no-param-reassign */

--- a/src/redux/rootSaga.js
+++ b/src/redux/rootSaga.js
@@ -123,6 +123,7 @@ import {
   setAutoRefreshInterval,
   setDarkMode,
   setServerSideFiltering,
+  setRelativeDates,
   clearLocalCache,
 } from './settings/sagas';
 
@@ -244,6 +245,7 @@ export default function* rootSaga() {
     setAutoRefreshInterval(),
     setDarkMode(),
     setServerSideFiltering(),
+    setRelativeDates(),
     clearLocalCache(),
 
     // Connection

--- a/src/redux/settings/actions.js
+++ b/src/redux/settings/actions.js
@@ -36,6 +36,9 @@ export const SET_DARK_MODE_COMPLETED = 'SET_DARK_MODE_COMPLETED';
 export const SET_SERVER_SIDE_FILTERING_REQUESTED = 'SET_SERVER_SIDE_FILTERING_REQUESTED';
 export const SET_SERVER_SIDE_FILTERING_COMPLETED = 'SET_SERVER_SIDE_FILTERING_COMPLETED';
 
+export const SET_RELATIVE_DATES_REQUESTED = 'SET_RELATIVE_DATES_REQUESTED';
+export const SET_RELATIVE_DATES_COMPLETED = 'SET_RELATIVE_DATES_COMPLETED';
+
 // Define Actions
 export const toggleSettingsModal = () => ({
   type: TOGGLE_SETTINGS_REQUESTED,
@@ -92,4 +95,9 @@ export const setDarkMode = (darkMode) => ({
 export const setServerSideFiltering = (serverSideFiltering) => ({
   type: SET_SERVER_SIDE_FILTERING_REQUESTED,
   serverSideFiltering,
+});
+
+export const setRelativeDates = (relativeDates) => ({
+  type: SET_RELATIVE_DATES_REQUESTED,
+  relativeDates,
 });

--- a/src/redux/settings/reducers.js
+++ b/src/redux/settings/reducers.js
@@ -27,6 +27,8 @@ import {
   SET_DARK_MODE_COMPLETED,
   SET_SERVER_SIDE_FILTERING_REQUESTED,
   SET_SERVER_SIDE_FILTERING_COMPLETED,
+  SET_RELATIVE_DATES_REQUESTED,
+  SET_RELATIVE_DATES_COMPLETED,
 } from './actions';
 
 const settings = produce(
@@ -139,6 +141,15 @@ const settings = produce(
         draft.status = SET_SERVER_SIDE_FILTERING_COMPLETED;
         break;
 
+      case SET_RELATIVE_DATES_REQUESTED:
+        draft.status = SET_RELATIVE_DATES_REQUESTED;
+        break;
+
+      case SET_RELATIVE_DATES_COMPLETED:
+        draft.relativeDates = action.relativeDates;
+        draft.status = SET_RELATIVE_DATES_COMPLETED;
+        break;
+
       default:
         break;
     }
@@ -164,6 +175,7 @@ const settings = produce(
       },
     ],
     darkMode: false,
+    relativeDates: false,
     status: '',
   },
 );

--- a/src/redux/settings/sagas.js
+++ b/src/redux/settings/sagas.js
@@ -40,6 +40,8 @@ import {
   SET_DARK_MODE_COMPLETED,
   SET_SERVER_SIDE_FILTERING_REQUESTED,
   SET_SERVER_SIDE_FILTERING_COMPLETED,
+  SET_RELATIVE_DATES_REQUESTED,
+  SET_RELATIVE_DATES_COMPLETED,
 } from './actions';
 
 import selectSettings from './selectors';
@@ -218,5 +220,19 @@ export function* setServerSideFilteringImpl(action) {
   yield put({
     type: SET_SERVER_SIDE_FILTERING_COMPLETED,
     serverSideFiltering,
+  });
+}
+
+export function* setRelativeDates() {
+  yield takeLatest(SET_RELATIVE_DATES_REQUESTED, setRelativeDatesImpl);
+}
+
+export function* setRelativeDatesImpl(action) {
+  const {
+    relativeDates,
+  } = action;
+  yield put({
+    type: SET_RELATIVE_DATES_COMPLETED,
+    relativeDates,
   });
 }

--- a/src/redux/settings/sagas.test.js
+++ b/src/redux/settings/sagas.test.js
@@ -27,6 +27,8 @@ import {
   SET_AUTO_REFRESH_INTERVAL_COMPLETED,
   SET_DARK_MODE_REQUESTED,
   SET_DARK_MODE_COMPLETED,
+  SET_RELATIVE_DATES_REQUESTED,
+  SET_RELATIVE_DATES_COMPLETED,
 } from './actions';
 import {
   setDefaultSinceDateTenor,
@@ -35,6 +37,7 @@ import {
   setAutoAcceptIncidentsQuery,
   setAutoRefreshInterval,
   setDarkMode,
+  setRelativeDates,
 } from './sagas';
 
 describe('Sagas: Settings', () => {
@@ -71,6 +74,7 @@ describe('Sagas: Settings', () => {
         serverSideFiltering: true,
         searchAllCustomDetails: false,
         respondersInEpFilter: false,
+        relativeDates: false,
         status: SET_DEFAULT_SINCE_DATE_TENOR_COMPLETED,
       })
       .silentRun();
@@ -108,6 +112,7 @@ describe('Sagas: Settings', () => {
         serverSideFiltering: true,
         searchAllCustomDetails: false,
         respondersInEpFilter: false,
+        relativeDates: false,
         status: SET_ALERT_CUSTOM_DETAIL_COLUMNS_COMPLETED,
       })
       .silentRun();
@@ -148,6 +153,7 @@ describe('Sagas: Settings', () => {
         serverSideFiltering: true,
         searchAllCustomDetails: false,
         respondersInEpFilter: false,
+        relativeDates: false,
         status: SET_MAX_RATE_LIMIT_COMPLETED,
       })
       .silentRun();
@@ -185,6 +191,7 @@ describe('Sagas: Settings', () => {
         serverSideFiltering: true,
         searchAllCustomDetails: false,
         respondersInEpFilter: false,
+        relativeDates: false,
         status: SET_AUTO_ACCEPT_INCIDENTS_QUERY_COMPLETED,
       })
       .silentRun();
@@ -225,6 +232,7 @@ describe('Sagas: Settings', () => {
         serverSideFiltering: true,
         searchAllCustomDetails: false,
         respondersInEpFilter: false,
+        relativeDates: false,
         status: SET_AUTO_REFRESH_INTERVAL_COMPLETED,
       })
       .silentRun();
@@ -262,7 +270,46 @@ describe('Sagas: Settings', () => {
         serverSideFiltering: true,
         searchAllCustomDetails: false,
         respondersInEpFilter: false,
+        relativeDates: false,
         status: SET_DARK_MODE_COMPLETED,
+      })
+      .silentRun();
+  });
+  it('setRelativeDates', () => {
+    const relativeDates = true;
+    return expectSaga(setRelativeDates)
+      .withReducer(settings)
+      .dispatch({
+        type: SET_RELATIVE_DATES_REQUESTED,
+        relativeDates,
+      })
+      .put({
+        type: SET_RELATIVE_DATES_COMPLETED,
+        relativeDates,
+      })
+      .hasFinalState({
+        displaySettingsModal: false,
+        displayColumnsModal: false,
+        defaultSinceDateTenor: '1 Day',
+        maxRateLimit: 200,
+        autoAcceptIncidentsQuery: true,
+        autoRefreshInterval: 5,
+        alertCustomDetailFields: [
+          {
+            label: 'Environment:details.env',
+            value: 'Environment:details.env',
+            columnType: 'alert',
+            Header: 'Environment',
+            accessorPath: 'details.env',
+            aggregator: null,
+          },
+        ],
+        darkMode: false,
+        serverSideFiltering: true,
+        searchAllCustomDetails: false,
+        respondersInEpFilter: false,
+        relativeDates: true,
+        status: SET_RELATIVE_DATES_COMPLETED,
       })
       .silentRun();
   });


### PR DESCRIPTION
Introduces a relative date format setting, to address requests for more easily understanding the age of an incident. A tooltip is also added with the exact date and time.

Closes #61 

![Screenshot 2023-07-10 at 11 53 17](https://github.com/PagerDuty/pd-live-react/assets/1533562/e4f0e4f1-473b-4f95-87fe-1baf9b3b1eff)
