### PR TITLE
Ensure PersonInitialsComponent still renders even if users map isn't loaded yet

### DIFF
--- a/src/components/IncidentTable/subcomponents/PersonInitialsComponents.js
+++ b/src/components/IncidentTable/subcomponents/PersonInitialsComponents.js
@@ -30,17 +30,20 @@ const PersonInitialsComponent = ({
       user,
     }) => {
       let color;
+      let email;
       if (usersMap[user.id]) {
         color = usersMap[user.id].color.replace('-', '');
+        email = usersMap[user.id].email;
       } else {
         color = 'black';
+        email = '';
       }
       return {
         summary: user.summary,
         // initials: getInitials(user.summary),
         id: user.id,
         html_url: user.html_url,
-        email: usersMap[user.id].email,
+        email,
         color: CSS.supports && CSS.supports('color', color) ? color : 'black',
       };
     })


### PR DESCRIPTION
At reload of the application, it's possible for the async loading of users to take longer than the rendering of the incident table (larger number of users, small number of queried incidents).

Should handle this similar to the user color, where we have a default value if the user lookup is undefined.

Signed-off-by: Gavin Reynolds <greynolds@pagerduty.com>
