### PR TITLE
Fix "You passed a container to the second argument of root.render(...)" warning

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -46,7 +46,6 @@ root.render(
       </React.StrictMode> */}
     </PersistGate>
   </Provider>,
-  document.getElementById('root'),
 );
 
 // If you want to start measuring performance in your app, pass a function


### PR DESCRIPTION
Fix "You passed a container to the second argument of root.render(...). You don't need to pass it again since you already passed it to create the root." warning

Signed-off-by: Gavin Reynolds <greynolds@pagerduty.com>
