### PR TITLE
respect the disable_edit_priority ability

### DIFF
--- a/src/components/IncidentActions/IncidentActionsComponent.test.js
+++ b/src/components/IncidentActions/IncidentActionsComponent.test.js
@@ -56,6 +56,7 @@ describe('IncidentActionsComponent', () => {
     settings: {
       darkMode: false,
     },
+    connection: { abilities: [] },
   };
 
   const tempStoreMap = { ...baseStoreMap };
@@ -101,5 +102,13 @@ describe('IncidentActionsComponent', () => {
     componentWrapper(store, IncidentActionsComponent);
 
     expect(screen.getByRole('button', { name: 'Merge' })).toBeEnabled();
+  });
+
+  it('should deactivate priority button when disable_edit_priority ability is set', () => {
+    tempStoreMap.connection = { abilities: ['disable_edit_priority'] };
+    store = mockStore(tempStoreMap);
+    componentWrapper(store, IncidentActionsComponent);
+
+    expect(screen.getByRole('button', { name: 'Update Priority' })).toBeDisabled();
   });
 });

--- a/src/components/IncidentActions/subcomponents/PriorityMenu.jsx
+++ b/src/components/IncidentActions/subcomponents/PriorityMenu.jsx
@@ -34,12 +34,17 @@ const PriorityMenu = () => {
   } = useTranslation();
   const selectedRows = useSelector((state) => state.incidentTable.selectedRows);
   const priorities = useSelector((state) => state.priorities.priorities);
+  const abilities = useSelector((state) => state.connection.abilities);
   const dispatch = useDispatch();
   const updatePriority = (incidents, priorityId) => {
     dispatch(updatePriorityConnected(incidents, priorityId));
   };
 
-  const enabled = useMemo(() => selectedRows.length > 0, [selectedRows]);
+  const enabled = useMemo(() => (
+    selectedRows.length > 0
+    && Array.isArray(abilities)
+    && !abilities.includes('disable_edit_priority')
+  ), [selectedRows]);
 
   return (
     <Menu>


### PR DESCRIPTION
This PR will make PDlive disable the priority menu if `disable_edit_priority` is present in abilities, indicating that the `disable_edit_priority` feature flag is set on the account