### PR TITLE
Deselect rows as actions are requested rather than completed

### DIFF
--- a/cypress/e2e/Incidents/incidents.spec.js
+++ b/cypress/e2e/Incidents/incidents.spec.js
@@ -230,6 +230,9 @@ describe('Manage Open Incidents', { failFast: { enabled: true } }, () => {
     selectIncident(0);
     cy.get('#incident-action-resolve-button').click();
     checkActionAlertsModalContent('have been resolved');
+    // and now show all resolved status (#380)
+    cy.get('.query-status-resolved-button').check({ force: true });
+    waitForIncidentTable();
   });
 
   it('Update priority of singular incidents', () => {

--- a/cypress/e2e/Incidents/incidents.spec.js
+++ b/cypress/e2e/Incidents/incidents.spec.js
@@ -174,7 +174,7 @@ describe('Manage Open Incidents', { failFast: { enabled: true } }, () => {
     checkActionAlertsModalContent('Requested additional response for incident(s)');
     cy.get(`@selectedIncidentId_${incidentIdx}`).then((incidentId) => {
       checkIncidentCellContent(incidentId, 'Responders', 'UA');
-      checkPopoverContent(incidentId, 'Responders', 'user_a1@example.com');
+      checkPopoverContent(incidentId, 'Responders', 'User A');
       checkIncidentCellContent(incidentId, 'Latest Log Entry Type', 'responder_request');
     });
 
@@ -185,7 +185,7 @@ describe('Manage Open Incidents', { failFast: { enabled: true } }, () => {
     checkActionAlertsModalContent('Requested additional response for incident(s)');
     cy.get(`@selectedIncidentId_${incidentIdx}`).then((incidentId) => {
       checkIncidentCellContent(incidentId, 'Responders', 'UA');
-      checkPopoverContent(incidentId, 'Responders', 'user_a1@example.com');
+      checkPopoverContent(incidentId, 'Responders', 'User A');
       checkIncidentCellContent(incidentId, 'Latest Log Entry Type', 'responder_request');
     });
   });
@@ -199,7 +199,9 @@ describe('Manage Open Incidents', { failFast: { enabled: true } }, () => {
     checkActionAlertsModalContent('Requested additional response for incident(s)');
     cy.get(`@selectedIncidentId_${incidentIdx}`).then((incidentId) => {
       checkIncidentCellContent(incidentId, 'Responders', 'UA');
-      checkPopoverContent(incidentId, 'Responders', 'user_a1@example.com');
+      checkIncidentCellContent(incidentId, 'Responders', 'UB');
+      checkPopoverContent(incidentId, 'Responders', 'User A');
+      checkPopoverContent(incidentId, 'Responders', 'User B');
       checkIncidentCellContent(incidentId, 'Latest Log Entry Type', 'responder_request');
     });
   });

--- a/cypress/e2e/Incidents/incidents.spec.js
+++ b/cypress/e2e/Incidents/incidents.spec.js
@@ -49,7 +49,7 @@ describe('Manage Open Incidents', { failFast: { enabled: true } }, () => {
 
   it('Select all incidents', () => {
     selectAllIncidents();
-    cy.get('.selected-incidents-badge').then(($el) => {
+    cy.get('.selected-incidents-badge').should(($el) => {
       const text = $el.text();
       const incidentNumbers = text.split(' ')[0].split('/');
       expect(incidentNumbers[0]).to.equal(incidentNumbers[1]);
@@ -59,7 +59,7 @@ describe('Manage Open Incidents', { failFast: { enabled: true } }, () => {
     // Shift-select multiple incidents
     selectIncident(0);
     selectIncident(4, true);
-    cy.get('.selected-incidents-badge').then(($el) => {
+    cy.get('.selected-incidents-badge').should(($el) => {
       const text = $el.text();
       const incidentNumbers = text.split(' ')[0].split('/');
       expect(incidentNumbers[0]).to.equal('5');

--- a/cypress/support/util/common.js
+++ b/cypress/support/util/common.js
@@ -49,7 +49,7 @@ export const selectAllIncidents = () => {
 };
 
 export const checkNoIncidentsSelected = () => {
-  cy.get('.selected-incidents-badge').then(($el) => {
+  cy.get('.selected-incidents-badge').should(($el) => {
     const text = $el.text();
     const incidentNumbers = text.split(' ')[0].split('/');
     expect(incidentNumbers[0]).to.equal('0');

--- a/cypress/support/util/common.js
+++ b/cypress/support/util/common.js
@@ -29,7 +29,10 @@ export const waitForIncidentTable = () => {
 export const waitForAlerts = () => {
   // eslint-disable-next-line cypress/no-unnecessary-waiting
   cy.wait(3000); // Required for query debounce
-  cy.get('.selected-incidents-ctr', { timeout: 60000 }).should('not.include.text', 'Fetching Alerts');
+  cy.get('.selected-incidents-ctr', { timeout: 60000 }).should(
+    'not.include.text',
+    'Fetching Alerts',
+  );
 };
 
 export const selectIncident = (incidentIdx = 0, shiftKey = false) => {

--- a/src/components/IncidentTable/IncidentTableComponent.jsx
+++ b/src/components/IncidentTable/IncidentTableComponent.jsx
@@ -441,11 +441,15 @@ const IncidentTableComponent = () => {
   // Handle deselecting rows after incident action has completed
   useEffect(() => {
     // TODO: Get user feedback on this workflow
-    if (incidentActionsStatus === 'ACTION_COMPLETED') {
-      toggleAllRowsSelected(false);
-    } else if (
-      !incidentActionsStatus.includes('TOGGLE')
-      && incidentActionsStatus.includes('COMPLETED')
+    // toggleAllRowsSelected only works on the currently filtered rows, therefore
+    // to fix #380 we can't wait for the incidentActionsStatus to be COMPLETED
+    //
+    // Workarounds using the stateReducer to clear selectedRowIds also don't appear to work on filtered out rows
+    // Therefore, clearing the checkbox in the UI before it is filtered out is the best we can do for now
+    if (
+      incidentActionsStatus === 'ACTION_COMPLETED'
+      || (!incidentActionsStatus.includes('TOGGLE')
+      && (incidentActionsStatus.includes('REQUESTED') || incidentActionsStatus.includes('COMPLETED')))
     ) {
       toggleAllRowsSelected(false);
     }

--- a/src/components/IncidentTable/IncidentTableComponent.jsx
+++ b/src/components/IncidentTable/IncidentTableComponent.jsx
@@ -438,7 +438,7 @@ const IncidentTableComponent = () => {
     return () => {};
   }, [selectedFlatRows]);
 
-  // Handle deselecting rows after incident action has completed
+  // Handle deselecting rows after incident action has been requested
   useEffect(() => {
     // TODO: Get user feedback on this workflow
     // toggleAllRowsSelected only works on the currently filtered rows, therefore
@@ -446,21 +446,21 @@ const IncidentTableComponent = () => {
     //
     // Workarounds using the stateReducer to clear selectedRowIds also don't appear to work on filtered out rows
     // Therefore, clearing the checkbox in the UI before it is filtered out is the best we can do for now
-    if (
-      incidentActionsStatus === 'ACTION_COMPLETED'
-      || (!incidentActionsStatus.includes('TOGGLE')
-      && (incidentActionsStatus.includes('REQUESTED') || incidentActionsStatus.includes('COMPLETED')))
-    ) {
+    const isActionRequested = incidentActionsStatus === 'ACTION_REQUESTED';
+    const isToggleAction = incidentActionsStatus.includes('TOGGLE');
+    const isRequestedOrCompleted = incidentActionsStatus.includes('REQUESTED') || incidentActionsStatus.includes('COMPLETED');
+
+    if (isActionRequested || (!isToggleAction && isRequestedOrCompleted)) {
       toggleAllRowsSelected(false);
     }
   }, [incidentActionsStatus]);
 
-  // deselect rows after response play has completed
+  // deselect rows after response play has requested
   // not adding this to the above useEffect because I don't want to
   // take a chance of deselecting too many times
   useEffect(() => {
     // TODO: Get user feedback on this workflow
-    if (responsePlaysStatus === 'RUN_RESPONSE_PLAY_COMPLETED') {
+    if (responsePlaysStatus.includes('RUN_RESPONSE_PLAY_REQUESTED') || responsePlaysStatus.includes('RUN_RESPONSE_PLAY_COMPLETED')) {
       toggleAllRowsSelected(false);
     }
   }, [responsePlaysStatus]);

--- a/src/components/IncidentTable/IncidentTableComponent.jsx
+++ b/src/components/IncidentTable/IncidentTableComponent.jsx
@@ -460,7 +460,10 @@ const IncidentTableComponent = () => {
   // take a chance of deselecting too many times
   useEffect(() => {
     // TODO: Get user feedback on this workflow
-    if (responsePlaysStatus.includes('RUN_RESPONSE_PLAY_REQUESTED') || responsePlaysStatus.includes('RUN_RESPONSE_PLAY_COMPLETED')) {
+    if (
+      responsePlaysStatus.includes('RUN_RESPONSE_PLAY_REQUESTED')
+      || responsePlaysStatus.includes('RUN_RESPONSE_PLAY_COMPLETED')
+    ) {
       toggleAllRowsSelected(false);
     }
   }, [responsePlaysStatus]);


### PR DESCRIPTION
Fix https://github.com/PagerDuty/pd-live-react/issues/380 by clearing incident checkboxes as actions are requested, rather than completed and potentially filtered out, to avoid react-table's toggleAllRowsSelected behaviour of only working on currently filtered rows

Signed-off-by: Gavin Reynolds <greynolds@pagerduty.com>
