### PR TITLE
Fetch Custom Details added to alerts from both email and event based alerts

### DIFF
--- a/src/config/column-generator.jsx
+++ b/src/config/column-generator.jsx
@@ -773,7 +773,11 @@ export const customAlertColumnForSavedColumn = (savedColumn) => {
     return null;
   }
   const accessor = (incident) => {
-    const path = `alerts[*].body.cef_details.${accessorPath}`;
+    // custom details are in both body.cef_details.details and body.details for events
+    // but only body.details is guaranteed to exist, and won't be null
+    // body.cef_details.details can be null if the alert is from an email
+    // const path = `alerts[*].body.cef_details.${accessorPath}`;
+    const path = `alerts[*].body.${accessorPath}`;
     let result = null;
     try {
       result = JSONPath({

--- a/src/mocks/incidents.test.js
+++ b/src/mocks/incidents.test.js
@@ -22,6 +22,14 @@ const generateMockAlert = () => {
   const message = faker.commerce.productDescription();
   const uuid = faker.string.uuid();
   const link = faker.internet.url();
+  const customDetails = {
+    quote,
+    'some obsecure field': uuid,
+    link,
+    object_details: {
+      key1: 'value1',
+    },
+  };
   return {
     type: 'alert',
     id: alertId,
@@ -30,18 +38,15 @@ const generateMockAlert = () => {
     created_at: createdAt,
     body: {
       contexts: [],
+      // custom details are in both body.cef_details.details and body.details for events
+      // but only body.details is guaranteed to exist, and won't be null
+      // body.cef_details.details can be null if the alert is from an email
+      details: customDetails,
       cef_details: {
         contexts: [],
         dedup_key: alertId,
         description: title,
-        details: {
-          quote,
-          'some obsecure field': uuid,
-          link,
-          object_details: {
-            key1: 'value1',
-          },
-        },
+        details: customDetails,
         event_class: jobType,
         message,
         mutations: [

--- a/src/redux/incidents/sagas.js
+++ b/src/redux/incidents/sagas.js
@@ -498,7 +498,10 @@ export function* filterIncidentsImpl() {
           // Handle case when '[*]' accessors are used
           const strippedAccessor = col.accessorPath.replace(/([[*\]])/g, '.');
           return (
-            `alerts.body.cef_details.${strippedAccessor}`
+            // custom details are in both body.cef_details.details and body.details for events
+            // but only body.details is guaranteed to exist, and won't be null
+            // body.cef_details.details can be null if the alert is from an email
+            `alerts.body.${strippedAccessor}`
               .split('.')
               // Handle case when special character is wrapped in quotation marks
               .map((a) => (a.includes("'") ? a.replaceAll("'", '') : a))
@@ -523,8 +526,11 @@ export function* filterIncidentsImpl() {
           const incidentAlertsForSearch = incidentAlerts[incident.id] instanceof Array ? incidentAlerts[incident.id] : [];
           const incidentAlertsForSearchWithFlattedCustomDetails = incidentAlertsForSearch.map(
             (alert) => {
-              const flattedCustomDetails = alert.body?.cef_details
-                ? Object.values(flattenObject(alert.body.cef_details)).join(' ')
+              // custom details are in both body.cef_details.details and body.details for events
+              // but only body.details is guaranteed to exist, and won't be null
+              // body.cef_details.details can be null if the alert is from an email
+              const flattedCustomDetails = alert.body?.details
+                ? Object.values(flattenObject(alert.body.details)).join(' ')
                 : '';
               return {
                 ...alert,

--- a/src/redux/incidents/sagas.test.js
+++ b/src/redux/incidents/sagas.test.js
@@ -154,7 +154,7 @@ describe('Sagas: Incidents', () => {
   it('filterIncidents: Search by Alert Custom Detail Field', () => {
     const mockIncident = mockIncidents[0];
     const customField = 'some obsecure field';
-    const customFieldValue = mockIncident.alerts[0].body.cef_details.details[customField];
+    const customFieldValue = mockIncident.alerts[0].body.details[customField];
     const expectedIncidentResult = [mockIncident];
     return expectSaga(filterIncidents)
       .withReducer(incidents)


### PR DESCRIPTION
Fix #377

Custom details are in both body.cef_details.details and body.details for events... however body.cef_details.details can be null if the alert is from an email, therefore switch to only use body.details to cover both cases.

Signed-off-by: Gavin Reynolds <greynolds@pagerduty.com>
