### PR TITLE
Fix Severity column is blank for incidents that come from email

### DIFF
--- a/src/config/column-generator.jsx
+++ b/src/config/column-generator.jsx
@@ -644,7 +644,17 @@ export const defaultAlertsColumns = () => [
     id: 'severity',
     header: 'Severity',
     columnType: 'alert',
-    accessor: (incident) => incident.alerts?.[0]?.body?.cef_details?.severity || '',
+    accessor: (incident) => {
+      if (
+        incident.alerts
+        && incident.alerts instanceof Array
+        && incident.alerts.length > 0
+        && incident.alerts[0] instanceof Object
+      ) {
+        return incident.alerts[0].severity || '--';
+      }
+      return '--';
+    },
     minWidth: 100,
     renderer: ({
       value, cell,


### PR DESCRIPTION
get severity from `.severity` in alert, not `.body.cef_details.severity`