### PR TITLE
Fix code scanning alert no. 117: Incomplete string escaping or encoding

### DIFF
--- a/cypress/support/util/common.js
+++ b/cypress/support/util/common.js
@@ -3,6 +3,7 @@
 import {
   api,
 } from '@pagerduty/pdjs';
+import cssesc from 'cssesc';
 
 export const pd = api({ token: Cypress.env('PD_USER_TOKEN') });
 
@@ -278,8 +279,8 @@ export const manageCustomColumnDefinitions = (customColumnDefinitions, type = 'a
     cy.get('button[aria-label="Add custom column"]').click();
     // Need to escape special characters in accessorPath
     // https://docs.cypress.io/faq/questions/using-cypress-faq#How-do-I-use-special-characters-with-cyget
-    const columnId = Cypress.$.escapeSelector(
-      [header, accessorPath, expression.replace(/:/g, '\\:')]
+    const columnId = cssesc(
+      [header, accessorPath, expression]
         .filter((value) => value !== '')
         .join(':'),
     );

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "styled-components": "^6.0.4",
     "use-debounce": "^9.0.3",
     "validator": "^13.12.0",
-    "web-vitals": "^3.5.2"
+    "web-vitals": "^3.5.2",
+    "cssesc": "^3.0.0"
   },
   "scripts": {
     "start": "vite",


### PR DESCRIPTION
Fixes [https://github.com/PagerDuty/pd-live-react/security/code-scanning/117](https://github.com/PagerDuty/pd-live-react/security/code-scanning/117)

To fix the problem, we need to ensure that all special characters, including backslashes, are properly escaped in the `expression` string. The best way to achieve this is to use a well-tested library for escaping CSS selectors, such as `cssesc`. This library handles all necessary escaping and ensures that the resulting string is safe to use in a CSS selector.

1. Install the `cssesc` library.
2. Import the `cssesc` library in the file.
3. Replace the manual escaping with the `cssesc` function to handle all necessary escaping.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
